### PR TITLE
[MMCA-4750] - Fix timestamp error for /eori/:eori/verified-email route

### DIFF
--- a/app/models/NotificationEmail.scala
+++ b/app/models/NotificationEmail.scala
@@ -17,6 +17,7 @@
 package models
 
 import play.api.libs.json.{JsString, Json, OFormat, Writes}
+import utils.DateTimeUtils.appendDefaultSeconds
 
 import java.time.LocalDateTime
 
@@ -27,7 +28,7 @@ case class NotificationEmail(address: String,
 object NotificationEmail {
 
   implicit val timestampWrites: Writes[LocalDateTime] = {
-    Writes[LocalDateTime](d => JsString(s"${d.toString}Z"))
+    Writes[LocalDateTime](d => JsString(s"${appendDefaultSeconds(d.toString)}Z"))
   }
 
   implicit val emailFormat: OFormat[NotificationEmail] = Json.format[NotificationEmail]

--- a/app/models/NotificationEmail.scala
+++ b/app/models/NotificationEmail.scala
@@ -17,7 +17,7 @@
 package models
 
 import play.api.libs.json.{JsString, Json, OFormat, Writes}
-import utils.DateTimeUtils.appendDefaultSeconds
+import utils.DateTimeUtils.appendDefaultSecondsInDateTime
 
 import java.time.LocalDateTime
 
@@ -28,7 +28,7 @@ case class NotificationEmail(address: String,
 object NotificationEmail {
 
   implicit val timestampWrites: Writes[LocalDateTime] = {
-    Writes[LocalDateTime](d => JsString(s"${appendDefaultSeconds(d.toString)}Z"))
+    Writes[LocalDateTime](d => JsString(s"${appendDefaultSecondsInDateTime(d.toString)}Z"))
   }
 
   implicit val emailFormat: OFormat[NotificationEmail] = Json.format[NotificationEmail]

--- a/app/utils/DateTimeUtils.scala
+++ b/app/utils/DateTimeUtils.scala
@@ -34,9 +34,9 @@ object DateTimeUtils {
     JsString(d.atOffset(ZoneOffset.UTC).truncatedTo(
       ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_DATE_TIME))
 
-  def appendDefaultSeconds(dateTimeString: String):String = {
-    val dateTimeStringSplitList = dateTimeString.split(colon)
+  def appendDefaultSecondsInDateTime(incomingDateTimeString: String):String = {
+    val dateTimeStringSplitList = incomingDateTimeString.split(colon)
 
-    if(dateTimeStringSplitList.size > 2) dateTimeString else s"$dateTimeString:00"
+    if(dateTimeStringSplitList.size > 2) incomingDateTimeString else s"$incomingDateTimeString:00"
   }
 }

--- a/app/utils/DateTimeUtils.scala
+++ b/app/utils/DateTimeUtils.scala
@@ -18,6 +18,7 @@ package utils
 
 import java.time.{LocalDateTime, ZoneId, ZoneOffset}
 import play.api.libs.json.{JsString, Writes}
+import utils.Utils.colon
 
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -32,4 +33,10 @@ object DateTimeUtils {
   def dateTimeWritesIsoUtc: Writes[LocalDateTime] = (d: java.time.LocalDateTime) =>
     JsString(d.atOffset(ZoneOffset.UTC).truncatedTo(
       ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_DATE_TIME))
+
+  def appendDefaultSeconds(dateTimeString: String):String = {
+    val dateTimeStringSplitList = dateTimeString.split(colon)
+
+    if(dateTimeStringSplitList.size > 2) dateTimeString else s"$dateTimeString:00"
+  }
 }

--- a/app/utils/Utils.scala
+++ b/app/utils/Utils.scala
@@ -21,4 +21,5 @@ object Utils {
   val hyphen = "-"
   val emptyString = ""
   val singleSpace = " "
+  val colon = ":"
 }

--- a/test/models/NotificationEmailSpec.scala
+++ b/test/models/NotificationEmailSpec.scala
@@ -39,6 +39,10 @@ class NotificationEmailSpec extends SpecBase {
     "generate correct output" in new Setup {
       Json.toJson(notifMailOb) mustBe Json.parse(notificationEmailJsStringForWrites)
     }
+
+    "generate correct output when time has no seconds" in new Setup {
+      Json.toJson(notifMailObWithNoSeconds) mustBe Json.parse(notificationEmailWith00SecondsJsStringForWrites)
+    }
   }
 
   trait Setup {
@@ -50,6 +54,7 @@ class NotificationEmailSpec extends SpecBase {
     val seconds = 44
 
     val timeStamp: LocalDateTime = LocalDateTime.of(year, month, dayOfTheMonth, hourOfTheDay, minutes, seconds)
+    val timeStampWith00Seconds: LocalDateTime = LocalDateTime.of(year, month, dayOfTheMonth, hourOfTheDay, minutes)
 
     val undeliverableEvent: UndeliverableInformationEvent =
       UndeliverableInformationEvent(id = "test_id",
@@ -63,6 +68,11 @@ class NotificationEmailSpec extends SpecBase {
 
     val notifMailOb: NotificationEmail = NotificationEmail(address = "test_address",
       timeStamp,
+      undeliverable =
+        Some(UndeliverableInformation("test_sub", "test_event_id", "test_group_id", timeStamp, undeliverableEvent)))
+
+    val notifMailObWithNoSeconds: NotificationEmail = NotificationEmail(address = "test_address",
+      timeStampWith00Seconds,
       undeliverable =
         Some(UndeliverableInformation("test_sub", "test_event_id", "test_group_id", timeStamp, undeliverableEvent)))
 
@@ -87,6 +97,23 @@ class NotificationEmailSpec extends SpecBase {
       """
         |{"address":"test_address",
         |"timestamp":"2024-05-17T12:55:44Z",
+        |"undeliverable":{
+        |"subject":"test_sub",
+        |"eventId":"test_event_id",
+        |"groupId":"test_group_id",
+        |"timestamp":"2024-05-17T12:55:44",
+        |"event":{
+        |"id":"test_id",
+        |"event":"circuit_breaker",
+        |"emailAddress":"test@abc.com",
+        |"detected":"test",
+        |"enrolment":"test_enrol"
+        |}}}""".stripMargin
+
+    val notificationEmailWith00SecondsJsStringForWrites: String =
+      """
+        |{"address":"test_address",
+        |"timestamp":"2024-05-17T12:55:00Z",
         |"undeliverable":{
         |"subject":"test_sub",
         |"eventId":"test_event_id",

--- a/test/utils/DateTimeUtilsSpec.scala
+++ b/test/utils/DateTimeUtilsSpec.scala
@@ -17,7 +17,7 @@
 package utils
 
 import play.api.libs.json.{JsString, Json}
-import utils.DateTimeUtils.{appendDefaultSeconds, rfc1123DateTimeFormatter, rfc1123DateTimePattern}
+import utils.DateTimeUtils.{appendDefaultSecondsInDateTime, rfc1123DateTimeFormatter, rfc1123DateTimePattern}
 
 import java.time.LocalDateTime
 
@@ -62,16 +62,16 @@ class DateTimeUtilsSpec extends SpecBase {
     }
   }
 
-  "appendDefaultSeconds" should {
+  "appendDefaultSecondsInDateTime" should {
 
     "append 00 seconds at the end if seconds' part is missing from DateTime" in {
-      appendDefaultSeconds("2007-03-20T01:02") mustBe "2007-03-20T01:02:00"
-      appendDefaultSeconds("2007-03-20T21:44") mustBe "2007-03-20T21:44:00"
+      appendDefaultSecondsInDateTime("2007-03-20T01:02") mustBe "2007-03-20T01:02:00"
+      appendDefaultSecondsInDateTime("2007-03-20T21:44") mustBe "2007-03-20T21:44:00"
     }
 
     "not modify the DateTime if seconds' part is already present" in {
-      appendDefaultSeconds("2007-03-20T01:02:46") mustBe "2007-03-20T01:02:46"
-      appendDefaultSeconds("2007-03-20T12:22:00") mustBe "2007-03-20T12:22:00"
+      appendDefaultSecondsInDateTime("2007-03-20T01:02:46") mustBe "2007-03-20T01:02:46"
+      appendDefaultSecondsInDateTime("2007-03-20T12:22:00") mustBe "2007-03-20T12:22:00"
     }
   }
 }

--- a/test/utils/DateTimeUtilsSpec.scala
+++ b/test/utils/DateTimeUtilsSpec.scala
@@ -17,7 +17,7 @@
 package utils
 
 import play.api.libs.json.{JsString, Json}
-import utils.DateTimeUtils.{rfc1123DateTimeFormatter, rfc1123DateTimePattern}
+import utils.DateTimeUtils.{appendDefaultSeconds, rfc1123DateTimeFormatter, rfc1123DateTimePattern}
 
 import java.time.LocalDateTime
 
@@ -59,6 +59,19 @@ class DateTimeUtilsSpec extends SpecBase {
       val date = LocalDateTime.of(year, month, dayOfMonth, hourOfTheDay, minutesOfTheHour, secondsOfTheMinute)
 
       Json.toJson(date)(DateTimeUtils.dateTimeWritesIsoUtc) mustBe JsString("2024-01-10T08:10:10Z")
+    }
+  }
+
+  "appendDefaultSeconds" should {
+
+    "append 00 seconds at the end if seconds' part is missing from DateTime" in {
+      appendDefaultSeconds("2007-03-20T01:02") mustBe "2007-03-20T01:02:00"
+      appendDefaultSeconds("2007-03-20T21:44") mustBe "2007-03-20T21:44:00"
+    }
+
+    "not modify the DateTime if seconds' part is already present" in {
+      appendDefaultSeconds("2007-03-20T01:02:46") mustBe "2007-03-20T01:02:46"
+      appendDefaultSeconds("2007-03-20T12:22:00") mustBe "2007-03-20T12:22:00"
     }
   }
 }

--- a/test/utils/UtilsSpec.scala
+++ b/test/utils/UtilsSpec.scala
@@ -16,7 +16,7 @@
 
 package utils
 
-import utils.Utils.{emptyString, hyphen, singleSpace}
+import utils.Utils.{colon, emptyString, hyphen, singleSpace}
 
 class UtilsSpec extends SpecBase {
 
@@ -37,4 +37,11 @@ class UtilsSpec extends SpecBase {
       singleSpace mustBe " "
     }
   }
+
+  "colon" should {
+    "return correct value" in {
+      colon mustBe ":"
+    }
+  }
+
 }


### PR DESCRIPTION
Description - Changes to append 00 as seconds in DateTime string if timestamp stored in Mongo db has 00 as seconds

Below has been done as part of this PR

- add tests to verify the json writes
- relevant code changes
- minor refactoring