### PR TITLE
[MMCA- 5201] - Handle errors from upstream for SUB09 call

### DIFF
--- a/app/connectors/Sub09Connector.scala
+++ b/app/connectors/Sub09Connector.scala
@@ -144,13 +144,23 @@ class Sub09Connector @Inject() (
           ACCEPT           -> "application/json"
         )
         .execute[SubscriptionResponse]
-        .flatMap { response =>
-          Future.successful(Some(response))
-        }
+        .flatMap(response => processSubscriptionResponse(response))
         .recover { case e =>
           log.error(s"Failed to retrieve SubscriptionResponse with error: $e")
           None
         }
     }
   }
+
+  private def processSubscriptionResponse(response: SubscriptionResponse) =
+    if (response.subscriptionDisplayResponse.responseDetail.isDefined) {
+      Future.successful(Some(response))
+    } else {
+      log.error(
+        s"SubscriptionResponse retrieved with business error:" +
+          s" ${response.subscriptionDisplayResponse.responseCommon.statusText.getOrElse(emptyString)}"
+      )
+
+      Future.successful(None)
+    }
 }

--- a/app/connectors/Sub09Connector.scala
+++ b/app/connectors/Sub09Connector.scala
@@ -26,8 +26,7 @@ import play.api.{Logger, LoggerLike}
 import services.MetricsReporterService
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
-import uk.gov.hmrc.http.{HeaderCarrier, ServiceUnavailableException, UpstreamErrorResponse}
-import play.api.http.Status.SERVICE_UNAVAILABLE
+import uk.gov.hmrc.http.HeaderCarrier
 import utils.DateTimeUtils.rfc1123DateTimeFormatter
 import utils.Utils.{emptyString, randomUUID, uri}
 
@@ -158,7 +157,7 @@ class Sub09Connector @Inject() (
     } else {
       log.error(
         s"SubscriptionResponse retrieved with business error:" +
-          s" ${response.subscriptionDisplayResponse.responseCommon.statusText.getOrElse(emptyString)}"
+          s" ${response.subscriptionDisplayResponse.responseCommon.statusText.getOrElse("statusText not available")}"
       )
 
       Future.successful(None)

--- a/app/models/responses/SubscriptionResponse.scala
+++ b/app/models/responses/SubscriptionResponse.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{Json, OFormat}
 
 case class SubscriptionResponse(subscriptionDisplayResponse: SubscriptionDisplayResponse)
 
-case class SubscriptionDisplayResponse(responseCommon: SubResponseCommon, responseDetail: SubResponseDetail)
+case class SubscriptionDisplayResponse(responseCommon: SubResponseCommon, responseDetail: Option[SubResponseDetail])
 
 case class CdsEstablishmentAddress(
   streetAndNumber: String,

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -30,9 +30,15 @@ class SubscriptionService @Inject() (sub09Connector: Sub09Connector)(implicit ec
     for {
       optSubscription <- sub09Connector.retrieveSubscriptions(eori)
     } yield optSubscription.fold(EmailVerifiedResponse(None)) { subsRes =>
-      subsRes.subscriptionDisplayResponse.responseDetail.contactInformation match {
-        case Some(ci) if ci.emailVerificationTimestamp.isDefined => EmailVerifiedResponse(ci.emailAddress)
-        case _                                                   => EmailVerifiedResponse(None)
+      val responseDetail = subsRes.subscriptionDisplayResponse.responseDetail
+
+      if (responseDetail.isDefined) {
+        responseDetail.get.contactInformation match {
+          case Some(ci) if ci.emailVerificationTimestamp.isDefined => EmailVerifiedResponse(ci.emailAddress)
+          case _                                                   => EmailVerifiedResponse(None)
+        }
+      } else {
+        EmailVerifiedResponse(None)
       }
     }
 
@@ -40,20 +46,36 @@ class SubscriptionService @Inject() (sub09Connector: Sub09Connector)(implicit ec
     for {
       optSubscription <- sub09Connector.retrieveSubscriptions(eori)
     } yield optSubscription.fold(EmailVerifiedResponse(None)) { subsRes =>
-      subsRes.subscriptionDisplayResponse.responseDetail.contactInformation match {
-        case Some(ci) if ci.emailAddress.isDefined => EmailVerifiedResponse(ci.emailAddress)
-        case _                                     => EmailVerifiedResponse(None)
+
+      val responseDetail = subsRes.subscriptionDisplayResponse.responseDetail
+
+      if (responseDetail.isDefined) {
+        responseDetail.get.contactInformation match {
+          case Some(ci) if ci.emailAddress.isDefined => EmailVerifiedResponse(ci.emailAddress)
+          case _                                     => EmailVerifiedResponse(None)
+        }
+      } else {
+        EmailVerifiedResponse(None)
       }
+
     }
 
   def getUnverifiedEmail(eori: EORI): Future[EmailUnverifiedResponse] =
     for {
       optSubscription <- sub09Connector.retrieveSubscriptions(eori)
     } yield optSubscription.fold(EmailUnverifiedResponse(None)) { subRes =>
-      subRes.subscriptionDisplayResponse.responseDetail.contactInformation match {
-        case Some(ci) if ci.emailVerificationTimestamp.isEmpty => EmailUnverifiedResponse(ci.emailAddress)
-        case _                                                 => EmailUnverifiedResponse(None)
+
+      val responseDetail = subRes.subscriptionDisplayResponse.responseDetail
+
+      if (responseDetail.isDefined) {
+        responseDetail.get.contactInformation match {
+          case Some(ci) if ci.emailVerificationTimestamp.isEmpty => EmailUnverifiedResponse(ci.emailAddress)
+          case _                                                 => EmailUnverifiedResponse(None)
+        }
+      } else {
+        EmailUnverifiedResponse(None)
       }
+
     }
 
 }

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -30,15 +30,14 @@ class SubscriptionService @Inject() (sub09Connector: Sub09Connector)(implicit ec
     for {
       optSubscription <- sub09Connector.retrieveSubscriptions(eori)
     } yield optSubscription.fold(EmailVerifiedResponse(None)) { subsRes =>
+
       val responseDetail = subsRes.subscriptionDisplayResponse.responseDetail
 
-      if (responseDetail.isDefined) {
-        responseDetail.get.contactInformation match {
+      responseDetail.fold(EmailVerifiedResponse(None)) { res =>
+        res.contactInformation match {
           case Some(ci) if ci.emailVerificationTimestamp.isDefined => EmailVerifiedResponse(ci.emailAddress)
           case _                                                   => EmailVerifiedResponse(None)
         }
-      } else {
-        EmailVerifiedResponse(None)
       }
     }
 
@@ -49,15 +48,12 @@ class SubscriptionService @Inject() (sub09Connector: Sub09Connector)(implicit ec
 
       val responseDetail = subsRes.subscriptionDisplayResponse.responseDetail
 
-      if (responseDetail.isDefined) {
-        responseDetail.get.contactInformation match {
+      responseDetail.fold(EmailVerifiedResponse(None)) { res =>
+        res.contactInformation match {
           case Some(ci) if ci.emailAddress.isDefined => EmailVerifiedResponse(ci.emailAddress)
           case _                                     => EmailVerifiedResponse(None)
         }
-      } else {
-        EmailVerifiedResponse(None)
       }
-
     }
 
   def getUnverifiedEmail(eori: EORI): Future[EmailUnverifiedResponse] =
@@ -67,15 +63,12 @@ class SubscriptionService @Inject() (sub09Connector: Sub09Connector)(implicit ec
 
       val responseDetail = subRes.subscriptionDisplayResponse.responseDetail
 
-      if (responseDetail.isDefined) {
-        responseDetail.get.contactInformation match {
+      responseDetail.fold(EmailUnverifiedResponse(None)) { res =>
+        res.contactInformation match {
           case Some(ci) if ci.emailVerificationTimestamp.isEmpty => EmailUnverifiedResponse(ci.emailAddress)
           case _                                                 => EmailUnverifiedResponse(None)
         }
-      } else {
-        EmailUnverifiedResponse(None)
       }
-
     }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,8 @@ import uk.gov.hmrc.DefaultBuildSettings.itSettings
 
 val appName = "customs-data-store"
 
-val silencerVersion  = "1.7.14"
-val bootstrapVersion = "9.0.0"
-val scala3_3_3       = "3.3.3"
+val silencerVersion = "1.7.14"
+val scala3_3_3      = "3.3.3"
 
 val testDirectory            = "test"
 val scalaStyleConfigFile     = "scalastyle-config.xml"
@@ -61,7 +60,9 @@ lazy val it = project
   .enablePlugins(PlayScala)
   .dependsOn(microservice % "test->test")
   .settings(itSettings())
-  .settings(libraryDependencies ++= Seq("uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % Test))
+  .settings(
+    libraryDependencies ++= Seq("uk.gov.hmrc" %% "bootstrap-test-play-30" % AppDependencies.bootstrapVersion % Test)
+  )
 
 addCommandAlias(
   "runAllChecks",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,17 +2,17 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.0.0"
+  val bootstrapVersion = "9.11.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc" %% "bootstrap-backend-play-30" % bootstrapVersion,
-    "org.typelevel" %% "cats-core" % "2.12.0",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30" % "2.1.0",
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-30" % bootstrapVersion,
+    "org.typelevel"     %% "cats-core"                 % "2.12.0",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"        % "2.6.0"
   )
 
   val test: Seq[ModuleID] = Seq(
-    "org.scalatestplus" %% "mockito-4-11" % "3.2.18.0",
-    "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % "test"
+    "org.scalatestplus" %% "mockito-4-11"           % "3.2.18.0",
+    "uk.gov.hmrc"       %% "bootstrap-test-play-30" % bootstrapVersion % "test"
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,20 +1,23 @@
 resolvers += "HMRC-open-artefacts-maven2" at "https://open.artefacts.tax.service.gov.uk/maven2"
 
-resolvers += Resolver.url("HMRC-open-artefacts-ivy", url(
-  "https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
+  Resolver.ivyStylePatterns
+)
 
 resolvers += Resolver.typesafeRepo("releases")
 
 // Resolves versions conflict
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.3")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.3")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.0.9")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" %
-  "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
+addSbtPlugin(
+  "org.scalastyle" %% "scalastyle-sbt-plugin" %
+    "1.0.0" exclude ("org.scala-lang.modules", "scala-xml_2.12")
+)
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % "2.0.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-uglify"   % "2.0.0")
+addSbtPlugin("org.scalameta"    % "sbt-scalafmt" % "2.5.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" 
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.3")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.6")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.0.9")
 
 addSbtPlugin(

--- a/test/connectors/Sub09ConnectorSpec.scala
+++ b/test/connectors/Sub09ConnectorSpec.scala
@@ -324,10 +324,12 @@ class Sub09ConnectorSpec extends SpecBase with WireMockSupportProvider {
   ) = {
 
     val actualSubsResponseCommon = actualResponse.subscriptionDisplayResponse.responseCommon
-    val actualSubsResponseDetail = actualResponse.subscriptionDisplayResponse.responseDetail.get
+    val actualSubsResponseDetail =
+      actualResponse.subscriptionDisplayResponse.responseDetail.getOrElse(defaultSubResponseDetails)
 
     val expectedSubsResponseCommon  = expectedResponse.subscriptionDisplayResponse.responseCommon
-    val expectedSubsResponseDetails = expectedResponse.subscriptionDisplayResponse.responseDetail.get
+    val expectedSubsResponseDetails =
+      expectedResponse.subscriptionDisplayResponse.responseDetail.getOrElse(defaultSubResponseDetails)
 
     actualSubsResponseCommon.status mustBe expectedSubsResponseCommon.status
     actualSubsResponseCommon.returnParameters.value mustBe expectedSubsResponseCommon.returnParameters.value

--- a/test/models/responses/SubscriptionResponseSpec.scala
+++ b/test/models/responses/SubscriptionResponseSpec.scala
@@ -48,14 +48,25 @@ class SubscriptionResponseSpec extends SpecBase {
           expectedResponseDetail.CDSEstablishmentAddress
       }
 
-      "Reads the response when response details are not present" in new Setup {
+      "Reads the response where responseDetail is not present" in new Setup {
         import models.responses.SubscriptionResponse.responseSubscriptionFormat
 
         val actualObject: SubscriptionResponse =
           Json.parse(subsResponseWithoutResponseDetailsString).as[SubscriptionResponse]
 
-        actualObject.subscriptionDisplayResponse.responseCommon.returnParameters.get mustBe
-          subsResponseWithoutResponseDetailsOb.subscriptionDisplayResponse.responseCommon.returnParameters.get
+        val actualResponseCommon: SubResponseCommon = actualObject.subscriptionDisplayResponse.responseCommon
+
+        val expectedResponseCommon: SubResponseCommon =
+          subsResponseWithoutResponseDetailsOb.subscriptionDisplayResponse.responseCommon
+
+        actualResponseCommon.status mustBe expectedResponseCommon.status
+        actualResponseCommon.statusText mustBe expectedResponseCommon.statusText
+        actualResponseCommon.processingDate mustBe expectedResponseCommon.processingDate
+
+        actualResponseCommon.returnParameters.getOrElse(
+          Array[ReturnParameters]()
+        ) mustBe expectedResponseCommon.returnParameters
+          .getOrElse(Array[ReturnParameters]())
 
         actualObject.subscriptionDisplayResponse.responseDetail mustBe empty
       }

--- a/test/models/responses/SubscriptionResponseSpec.scala
+++ b/test/models/responses/SubscriptionResponseSpec.scala
@@ -28,21 +28,24 @@ class SubscriptionResponseSpec extends SpecBase {
       "Reads the response" in new Setup {
         import models.responses.SubscriptionResponse.responseSubscriptionFormat
 
-        val actualObject: SubscriptionResponse = Json.fromJson(Json.parse(subsResponseString)).get
+        val actualObject: SubscriptionResponse = Json.parse(subsResponseString).as[SubscriptionResponse]
 
-        actualObject.subscriptionDisplayResponse.responseCommon.returnParameters.get mustBe
-          subsResponseOb.subscriptionDisplayResponse.responseCommon.returnParameters.get
+        actualObject.subscriptionDisplayResponse.responseCommon.returnParameters
+          .getOrElse(Array[ReturnParameters]()) mustBe
+          subsResponseOb.subscriptionDisplayResponse.responseCommon.returnParameters
+            .getOrElse(Array[ReturnParameters]())
 
-        val actualResponseDetail: SubResponseDetail = actualObject.subscriptionDisplayResponse.responseDetail.get
+        val actualResponseDetail: SubResponseDetail =
+          actualObject.subscriptionDisplayResponse.responseDetail.getOrElse(defaultSubResponseDetails)
 
         val expectedResponseDetail: SubResponseDetail =
-          subsResponseOb.subscriptionDisplayResponse.responseDetail.get
+          subsResponseOb.subscriptionDisplayResponse.responseDetail.getOrElse(defaultSubResponseDetails)
 
-        actualResponseDetail.XI_Subscription.get mustBe
-          expectedResponseDetail.XI_Subscription.get
+        actualResponseDetail.XI_Subscription mustBe
+          expectedResponseDetail.XI_Subscription
 
-        actualResponseDetail.contactInformation.get mustBe
-          expectedResponseDetail.contactInformation.get
+        actualResponseDetail.contactInformation mustBe
+          expectedResponseDetail.contactInformation
 
         actualResponseDetail.CDSEstablishmentAddress mustBe
           expectedResponseDetail.CDSEstablishmentAddress

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -69,6 +69,16 @@ class SubscriptionServiceSpec extends SpecBase {
           }
         }
       }
+
+      "return EmailVerifiedResponse with None when there is no response detail in SubscriptionResponse" in new Setup {
+        when(mockSub09Connector.retrieveSubscriptions(EORI("Trader EORI")))
+          .thenReturn(Future.successful(Some(subscriptionResponseWithNoResponseDetail)))
+
+        running(app) {
+          val result = await(service.getVerifiedEmail(EORI("Trader EORI")))
+          result mustBe EmailVerifiedResponse(None)
+        }
+      }
     }
 
     "getEmailAddress" should {
@@ -97,6 +107,16 @@ class SubscriptionServiceSpec extends SpecBase {
           }
         }
       }
+
+      "return EmailVerifiedResponse with None when there is no response detail in SubscriptionResponse" in new Setup {
+        when(mockSub09Connector.retrieveSubscriptions(EORI("Trader EORI")))
+          .thenReturn(Future.successful(Some(subscriptionResponseWithNoResponseDetail)))
+
+        running(app) {
+          val result = await(service.getEmailAddress(EORI("Trader EORI")))
+          result mustBe EmailVerifiedResponse(None)
+        }
+      }
     }
 
     "getUnverifiedEmail" should {
@@ -123,6 +143,16 @@ class SubscriptionServiceSpec extends SpecBase {
           result.map { eunv =>
             eunv mustBe EmailUnverifiedResponse(Option(EmailAddress(emailAddress)))
           }
+        }
+      }
+
+      "return EmailUnverifiedResponse with None when there is no response detail in SubscriptionResponse" in new Setup {
+        when(mockSub09Connector.retrieveSubscriptions(EORI("Trader EORI")))
+          .thenReturn(Future.successful(Some(subscriptionResponseWithNoResponseDetail)))
+
+        running(app) {
+          val result = await(service.getUnverifiedEmail(EORI("Trader EORI")))
+          result mustBe EmailUnverifiedResponse(None)
         }
       }
     }
@@ -229,6 +259,10 @@ class SubscriptionServiceSpec extends SpecBase {
 
     val subscriptionResponseWithTimestamp: SubscriptionResponse = SubscriptionResponse(
       SubscriptionDisplayResponse(responseCommon, Some(responseDetailWithTimestamp))
+    )
+
+    val subscriptionResponseWithNoResponseDetail: SubscriptionResponse = SubscriptionResponse(
+      SubscriptionDisplayResponse(responseCommon, None)
     )
   }
 }

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -220,15 +220,15 @@ class SubscriptionServiceSpec extends SpecBase {
       responseDetail.copy(contactInformation = Some(contactInfoWithTimeStamp))
 
     val subscriptionResponse: SubscriptionResponse = SubscriptionResponse(
-      SubscriptionDisplayResponse(responseCommon, responseDetail)
+      SubscriptionDisplayResponse(responseCommon, Some(responseDetail))
     )
 
     val subscriptionResponseWithContactInfo: SubscriptionResponse = SubscriptionResponse(
-      SubscriptionDisplayResponse(responseCommon, responseDetailWithContactInfo)
+      SubscriptionDisplayResponse(responseCommon, Some(responseDetailWithContactInfo))
     )
 
     val subscriptionResponseWithTimestamp: SubscriptionResponse = SubscriptionResponse(
-      SubscriptionDisplayResponse(responseCommon, responseDetailWithTimestamp)
+      SubscriptionDisplayResponse(responseCommon, Some(responseDetailWithTimestamp))
     )
   }
 }

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -16,6 +16,7 @@
 
 package utils
 
+import models.responses.{CdsEstablishmentAddress, ContactInformation, SubResponseDetail, VatId, XiSubscription}
 import models.{EORI, EmailAddress}
 
 object TestData {
@@ -36,4 +37,24 @@ object TestData {
   val VAT_ID                      = "242"
 
   val AUTH_BEARER_TOKEN_VALUE = "Bearer secret-token"
+
+  val defaultSubResponseDetails: SubResponseDetail = SubResponseDetail(
+    EORINo = None,
+    EORIStartDate = None,
+    EORIEndDate = None,
+    CDSFullName = "Tony Stark",
+    CDSEstablishmentAddress = CdsEstablishmentAddress("86 Mysore Road", "London", Some("SW11 5RZ"), "GB"),
+    establishmentInTheCustomsTerritoryOfTheUnion = None,
+    typeOfLegalEntity = None,
+    contactInformation = None,
+    VATIDs = None,
+    thirdCountryUniqueIdentificationNumber = None,
+    consentToDisclosureOfPersonalData = None,
+    shortName = None,
+    dateOfEstablishment = None,
+    typeOfPerson = None,
+    principalEconomicActivity = None,
+    ETMP_Master_Indicator = false,
+    XI_Subscription = None
+  )
 }

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -16,7 +16,7 @@
 
 package utils
 
-import models.responses.{CdsEstablishmentAddress, ContactInformation, SubResponseDetail, VatId, XiSubscription}
+import models.responses.{CdsEstablishmentAddress, SubResponseDetail}
 import models.{EORI, EmailAddress}
 
 object TestData {


### PR DESCRIPTION
Description - Code changes to handle the SubscriptionDisplayResponse when response contains the business error and does not contain responseDetail

Below has been done as part of this PR

- [x] responseDetail is made optional in SubscriptionDisplayResponse and update the classes where responseDetail is used
- [x] handle SubscriptionDisplayResponse when responseDetail is not present and add business error related error log
- [x] add tests
- [x] update existing tests
- [x] update test data
- [x] minor refactoring
- [x] use of scala formatter in few files (related to library upgrades)