### PR TITLE
[MMCA-5285] - Add check before making the email address undeliverable

### DIFF
--- a/app/controllers/UndeliverableEmailController.scala
+++ b/app/controllers/UndeliverableEmailController.scala
@@ -18,13 +18,14 @@ package controllers
 
 import connectors.Sub22Connector
 import models.repositories.NotificationEmailMongo
-import models.{FailedToProcess, ProcessResult, ProcessSucceeded, UndeliverableInformation}
-import play.api.mvc.{Action, ControllerComponents}
+import models.{FailedToProcess, NotificationEmail, ProcessResult, ProcessSucceeded, UndeliverableInformation}
+import play.api.mvc.{Action, ControllerComponents, Request, Result}
 import play.api.{Logger, LoggerLike}
 import repositories.EmailRepository
 import services.AuditingService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import utils.Utils.emptyString
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -43,21 +44,43 @@ class UndeliverableEmailController @Inject() (
       request.body.extractEori match {
 
         case Some(eori) =>
-          emailRepository
-            .findAndUpdate(eori, request.body)
-            .flatMap {
-              case Some(record) =>
-                auditingService.auditBouncedEmail(request.body)
-                updateSub22(request.body, record, eori).map(_ => NoContent)
-              case _            => Future.successful(NotFound)
+          val result = for {
+            existingNotifEmail: Option[NotificationEmail] <- emailRepository.get(eori)
+            existingEmailAddressOpt: Option[String]       <-
+              Future.successful(existingNotifEmail.fold(Option(emptyString))(notifEmail => Option(notifEmail.address)))
+          } yield {
+            val existingEmailAddress = existingEmailAddressOpt.getOrElse(emptyString)
+
+            if (existingEmailAddress == request.body.event.emailAddress) {
+              updateUndeliverableInformationForTheEori(request, eori)
+            } else {
+              log.warn("Mismatch between incoming (undeliverable) and existing (in database) email address")
+              Future.successful(NoContent)
             }
-            .recover { case err =>
-              log.error(s"Failed to mark email as undeliverable: ${err.getMessage}"); InternalServerError
-            }
+          }
+
+          result.flatten
 
         case None => Future.successful(BadRequest)
       }
   }
+
+  private def updateUndeliverableInformationForTheEori(
+    request: Request[UndeliverableInformation],
+    eori: String
+  )(implicit hc: HeaderCarrier): Future[Result] =
+    emailRepository
+      .findAndUpdate(eori, request.body)
+      .flatMap {
+        case Some(record) =>
+          auditingService.auditBouncedEmail(request.body)
+          updateSub22(request.body, record, eori).map(_ => NoContent)
+        case _            => Future.successful(NotFound)
+      }
+      .recover { case err =>
+        log.error(s"Failed to mark email as undeliverable: ${err.getMessage}")
+        InternalServerError
+      }
 
   private def updateSub22(
     undeliverableInformation: UndeliverableInformation,

--- a/test/controllers/UndeliverableEmailControllerSpec.scala
+++ b/test/controllers/UndeliverableEmailControllerSpec.scala
@@ -71,33 +71,8 @@ class UndeliverableEmailControllerSpec extends SpecBase {
 
     "return 404 if user has not been found in the data-store based on EORI for findAndUpdate" in new Setup {
 
-      val detectedDate: LocalDateTime = LocalDateTime.now()
-
-      val undeliverableInformationEvent: UndeliverableInformationEvent = UndeliverableInformationEvent(
-        "some-id",
-        "some event",
-        "some@email.com",
-        detectedDate.toString,
-        Some(code),
-        Some("unknown reason"),
-        s"HMRC-cus-ORG~EORINUMBER~$testEori",
-        Some("sdds")
-      )
-
-      val undeliverableInfo: UndeliverableInformation =
-        UndeliverableInformation(
-          "some subject",
-          "some event",
-          "someGroupId",
-          detectedDate,
-          undeliverableInformationEvent
-        )
-
-      val newNotificationEmail: NotificationEmail =
-        NotificationEmail("some@email.com", LocalDateTime.now(), Some(undeliverableInfo))
-
       when(mockEmailRepository.findAndUpdate(any(), any())).thenReturn(Future.successful(None))
-      when(mockEmailRepository.get(any())).thenReturn(Future.successful(Some(newNotificationEmail)))
+      when(mockEmailRepository.get(any())).thenReturn(Future.successful(Some(notificationEmail)))
 
       val request: FakeRequest[AnyContentAsJson] = FakeRequest(POST, postRoute).withJsonBody(
         Json.obj(
@@ -197,36 +172,12 @@ class UndeliverableEmailControllerSpec extends SpecBase {
     }
 
     "return 500 if the update to data to the database failed to write" in new Setup {
-      val detectedDate: LocalDateTime = LocalDateTime.now()
-
-      val undeliverableInformationEvent: UndeliverableInformationEvent = UndeliverableInformationEvent(
-        "some-id",
-        "some event",
-        "some@email.com",
-        detectedDate.toString,
-        Some(code),
-        Some("unknown reason"),
-        s"HMRC-cus-ORG~EORINUMBER~$testEori",
-        Some("sdds")
-      )
-
-      val undeliverableInfo: UndeliverableInformation =
-        UndeliverableInformation(
-          "some subject",
-          "some event",
-          "someGroupId",
-          detectedDate,
-          undeliverableInformationEvent
-        )
-
-      val newNotificationEmail: NotificationEmail =
-        NotificationEmail("some@email.com", LocalDateTime.now(), Some(undeliverableInfo))
 
       when(mockEmailRepository.findAndUpdate(any(), any())).thenReturn(
         Future.failed(new RuntimeException("something went wrong"))
       )
 
-      when(mockEmailRepository.get(any())).thenReturn(Future.successful(Some(newNotificationEmail)))
+      when(mockEmailRepository.get(any())).thenReturn(Future.successful(Some(notificationEmail)))
 
       val request: FakeRequest[AnyContentAsJson] = FakeRequest(POST, postRoute).withJsonBody(
         Json.obj(
@@ -257,18 +208,6 @@ class UndeliverableEmailControllerSpec extends SpecBase {
     }
 
     "return 204 if the update was successful to the database" in new Setup {
-      val detectedDate: LocalDateTime = LocalDateTime.now()
-
-      val undeliverableInformationEvent: UndeliverableInformationEvent = UndeliverableInformationEvent(
-        "some-id",
-        "some event",
-        "some@email.com",
-        detectedDate.toString,
-        Some(code),
-        Some("unknown reason"),
-        s"HMRC-cus-ORG~EORINUMBER~$testEori",
-        Some("sdds")
-      )
 
       val expectedRequest: UndeliverableInformation =
         UndeliverableInformation(
@@ -289,9 +228,6 @@ class UndeliverableEmailControllerSpec extends SpecBase {
         processed = false
       )
 
-      val newNotificationEmail: NotificationEmail =
-        NotificationEmail("some@email.com", LocalDateTime.now(), Some(expectedRequest))
-
       val newNotificationEmailMongo: NotificationEmailMongo = NotificationEmailMongo(
         "some@email.com",
         detectedDate,
@@ -307,7 +243,7 @@ class UndeliverableEmailControllerSpec extends SpecBase {
       when(mockEmailRepository.markAsSuccessful(any()))
         .thenReturn(Future.successful(true))
 
-      when(mockEmailRepository.get(any())).thenReturn(Future.successful(Some(newNotificationEmail)))
+      when(mockEmailRepository.get(any())).thenReturn(Future.successful(Some(notificationEmail)))
 
       val request: FakeRequest[AnyContentAsJson] = FakeRequest(POST, postRoute).withJsonBody(
         Json.obj(
@@ -340,33 +276,9 @@ class UndeliverableEmailControllerSpec extends SpecBase {
 
     "return 204 and perform no update" +
       " if email in the request body is different from the email stored in the database" in new Setup {
-        val detectedDate: LocalDateTime = LocalDateTime.now()
-
-        val undeliverableInformationEvent: UndeliverableInformationEvent = UndeliverableInformationEvent(
-          "some-id",
-          "some event",
-          "some@email.com",
-          detectedDate.toString,
-          Some(code),
-          Some("unknown reason"),
-          s"HMRC-cus-ORG~EORINUMBER~$testEori",
-          Some("sdds")
-        )
-
-        val undeliverableInfo: UndeliverableInformation =
-          UndeliverableInformation(
-            "some subject",
-            "some event",
-            "someGroupId",
-            detectedDate,
-            undeliverableInformationEvent
-          )
-
-        val newNotificationEmail: NotificationEmail =
-          NotificationEmail("some@email.com", LocalDateTime.now(), Some(undeliverableInfo))
 
         when(mockEmailRepository.get(any()))
-          .thenReturn(Future.successful(Some(newNotificationEmail)))
+          .thenReturn(Future.successful(Some(notificationEmail)))
 
         val request: FakeRequest[AnyContentAsJson] = FakeRequest(POST, postRoute).withJsonBody(
           Json.obj(
@@ -398,18 +310,6 @@ class UndeliverableEmailControllerSpec extends SpecBase {
       }
 
     "return 204 if the update failed to SUB22" in new Setup {
-      val detectedDate: LocalDateTime = LocalDateTime.now()
-
-      val undeliverableInformationEvent: UndeliverableInformationEvent = UndeliverableInformationEvent(
-        "some-id",
-        "some event",
-        "some@email.com",
-        detectedDate.toString,
-        Some(code),
-        Some("unknown reason"),
-        s"HMRC-cus-ORG~EORINUMBER~$testEori",
-        Some("sdds")
-      )
 
       val expectedRequest: UndeliverableInformation =
         UndeliverableInformation(
@@ -436,9 +336,6 @@ class UndeliverableEmailControllerSpec extends SpecBase {
         Some(undeliverableInformationMongo)
       )
 
-      val newNotificationEmail: NotificationEmail =
-        NotificationEmail("some@email.com", LocalDateTime.now(), Some(expectedRequest))
-
       when(mockEmailRepository.findAndUpdate(any(), any()))
         .thenReturn(Future.successful(Some(newNotificationEmailMongo)))
 
@@ -449,7 +346,7 @@ class UndeliverableEmailControllerSpec extends SpecBase {
         .thenReturn(Future.successful(true))
 
       when(mockEmailRepository.get(any()))
-        .thenReturn(Future.successful(Some(newNotificationEmail)))
+        .thenReturn(Future.successful(Some(notificationEmail)))
 
       val request: FakeRequest[AnyContentAsJson] = FakeRequest(POST, postRoute).withJsonBody(
         Json.obj(
@@ -488,6 +385,30 @@ class UndeliverableEmailControllerSpec extends SpecBase {
     val testEori                                       = "EoriNumber"
     val currentDateTimeString: String                  = LocalDateTime.now().toString
     val code                                           = 12
+    val detectedDate: LocalDateTime                    = LocalDateTime.now()
+
+    val undeliverableInformationEvent: UndeliverableInformationEvent = UndeliverableInformationEvent(
+      "some-id",
+      "some event",
+      "some@email.com",
+      detectedDate.toString,
+      Some(code),
+      Some("unknown reason"),
+      s"HMRC-cus-ORG~EORINUMBER~$testEori",
+      Some("sdds")
+    )
+
+    val undeliverableInfo: UndeliverableInformation =
+      UndeliverableInformation(
+        "some subject",
+        "some event",
+        "someGroupId",
+        detectedDate,
+        undeliverableInformationEvent
+      )
+
+    val notificationEmail: NotificationEmail =
+      NotificationEmail("some@email.com", LocalDateTime.now(), Some(undeliverableInfo))
 
     val postRoute: String = routes.UndeliverableEmailController.makeUndeliverable().url
 


### PR DESCRIPTION
Description - Add check before making the email address undeliverable

Below has been done as part of this PR

- [x] make the undeliverable info update conditional (only update if the existing and incoming email address is the same)
- [x] add and update tests
- [x] minor refactoring