### PR TITLE
[MMCA-5463] - Fix SUB09 response mapping for retrieving XI EORI information

### DIFF
--- a/app/connectors/Sub09Connector.scala
+++ b/app/connectors/Sub09Connector.scala
@@ -18,7 +18,7 @@ package connectors
 
 import config.AppConfig
 import config.Headers.*
-import models.responses.SubscriptionResponse
+import models.responses.{PbeAddress, SubscriptionResponse}
 import models.{CompanyInformation, EORI, NotificationEmail, XiEoriInformation}
 import play.api.{Logger, LoggerLike}
 import services.MetricsReporterService
@@ -26,7 +26,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import utils.DateTimeUtils.rfc1123DateTimeFormatter
-import utils.Utils.{randomUUID, uri}
+import utils.Utils.{emptyString, randomUUID, uri}
 
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -81,7 +81,7 @@ class Sub09Connector @Inject() (
           xiSub              <- detail.XI_Subscription
           xiEori              = xiSub.XI_EORINo
           consent             = xiSub.XI_ConsentToDisclose
-          address            <- xiSub.PBEAddress
+          address            <- xiSub.PBEAddress orElse Some(PbeAddress(emptyString, None, None, None, None))
         } yield XiEoriInformation(xiEori, consent, address.toXiEoriAddress)
       }
 

--- a/app/models/UndeliverableInformationEvent.scala
+++ b/app/models/UndeliverableInformationEvent.scala
@@ -53,7 +53,7 @@ object UndeliverableInformationEvent {
       (JsPath \\ "code").readNullable[Int] and
       (JsPath \\ "reason").readNullable[String] and
       (JsPath \\ "enrolment").read[String] and
-      (JsPath \\ "source").readNullable[String])(UndeliverableInformationEvent.apply _)
+      (JsPath \\ "source").readNullable[String])(UndeliverableInformationEvent.apply)
 
   implicit val writes: OWrites[UndeliverableInformationEvent] = Json.writes[UndeliverableInformationEvent]
 }

--- a/app/repositories/HistoricEoriRepository.scala
+++ b/app/repositories/HistoricEoriRepository.scala
@@ -63,7 +63,7 @@ class DefaultHistoricEoriRepository @Inject() ()(
       })
 
   override def set(eoriHistory: Seq[EoriPeriod]): Future[HistoricEoriRepositoryResult] = {
-    val query = in("eoriHistory.eori", eoriHistory.map(_.eori): _*)
+    val query = in("eoriHistory.eori", eoriHistory.map(_.eori)*)
 
     val update = Updates.combine(
       Updates.set("eoriHistory", eoriHistory.map(Codecs.toBson(_))),
@@ -94,7 +94,7 @@ object EoriHistory {
     (
       (__ \ "eoriHistory").read[Seq[EoriPeriod]] and
         (__ \ "lastUpdated").read(MongoJavatimeFormats.localDateTimeReads)
-    )(EoriHistory.apply _)
+    )(EoriHistory.apply)
   implicit val format: Format[EoriHistory]    = Format(reads, Json.writes[EoriHistory])
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,11 @@ lazy val microservice = Project(appName, file("."))
     scalafmtPrintDiff := true,
     scalafmtFailOnErrors := true,
     scalacOptions := scalacOptions.value.diff(Seq("-Wunused:all")),
+    scalacOptions ++= Seq(
+      "-Wconf:src=routes/.*:s",
+      "-Wconf:msg=Flag.*repeatedly:s",
+      "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
+    ),
     Test / scalacOptions ++= Seq(
       "-Wunused:imports",
       "-Wunused:params",

--- a/test/connectors/Sub09ConnectorSpec.scala
+++ b/test/connectors/Sub09ConnectorSpec.scala
@@ -202,8 +202,11 @@ class Sub09ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .willReturn(ok(noXiEoriAddress))
       )
 
-      val result: Option[models.XiEoriInformation] = connector.getXiEoriInformation(testEori).futureValue
-      result.map(xiInfo => xiInfo mustBe Option(xiEoriInformationWithNoAddress))
+      val result: Option[XiEoriInformation] = await(connector.getXiEoriInformation(testEori))
+
+      result.getOrElse(
+        XiEoriInformation(emptyString, emptyString, XiEoriAddressInformation(emptyString, None, None, None, None))
+      ) mustBe xiEoriInformationWithNoAddress
 
       verifyEndPointUrlHit(sub09Url)
     }

--- a/test/connectors/Sub21ConnectorSpec.scala
+++ b/test/connectors/Sub21ConnectorSpec.scala
@@ -20,7 +20,6 @@ import config.AppConfig
 import models.*
 import models.responses.{GetEORIHistoryResponse, ResponseCommon, ResponseDetail}
 import org.mockito.ArgumentCaptor
-import play.api
 import play.api.http.Status.NOT_FOUND
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.*
@@ -49,7 +48,7 @@ class Sub21ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .willReturn(ok(response))
       )
 
-      val result: Seq[models.EoriPeriod] = connector.getEoriHistory(someEori).futureValue
+      connector.getEoriHistory(someEori).futureValue
       verifyEndPointUrlHit(url)
     }
 

--- a/test/connectors/Sub22ConnectorSpec.scala
+++ b/test/connectors/Sub22ConnectorSpec.scala
@@ -22,7 +22,6 @@ import config.AppConfig
 import models.responses.*
 import models.{UndeliverableInformation, UndeliverableInformationEvent}
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
-import play.api
 import play.api.libs.json.Json
 import play.api.test.Helpers.*
 import play.api.{Application, Configuration}
@@ -30,7 +29,6 @@ import uk.gov.hmrc.http.HeaderCarrier
 import utils.{SpecBase, WireMockSupportProvider}
 
 import java.time.LocalDateTime
-import scala.concurrent.ExecutionContext
 
 class Sub22ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/services/AuditingServiceSpec.scala
+++ b/test/services/AuditingServiceSpec.scala
@@ -21,7 +21,6 @@ import models.{UndeliverableInformation, UndeliverableInformationEvent}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.matchers.should.Matchers._
 import play.api._
 import play.api.libs.json.Json
 import play.api.test.Helpers.running


### PR DESCRIPTION
Description - Response mapping update in case of the absence of PBEAddress in XI_Subscription

Below has been done as part of this PR

- [x] update response mapping for default PBEAddress
- [x] fix warnings (that was getting generated as part of recent scala version update)
- [x] update scala options to remove the warnings
- [x] update existing test to match the result correctly for absent PBEAddress case